### PR TITLE
[FEAT] 게시글 등록 시 본문 크기 초과 예외 처리 및 입력값 복원

### DIFF
--- a/src/main/java/com/my/ex/controller/BoardController.java
+++ b/src/main/java/com/my/ex/controller/BoardController.java
@@ -99,7 +99,35 @@ public class BoardController {
 	
 	// 게시글 등록
 	@RequestMapping(value = "/createBoard", method = RequestMethod.POST )
-	public String createBoard(BoardDto dto, RedirectAttributes rttr) throws JsonParseException, JsonMappingException, IOException {
+	public String createBoard(BoardDto dto, Model model, RedirectAttributes rttr) throws JsonParseException, JsonMappingException, IOException {
+		String bContent = dto.getbContent();
+		if(bContent.getBytes().length > 4000) {
+			System.out.println("4000바이트 초과");
+			
+			// 에러 메시지
+			model.addAttribute("error", "입력하신 내용이 너무 깁니다. 4000바이트를 초과했습니다.");
+			
+			/* 게시글 등록 페이지로 이동 */
+			// 사용자가 작성했던 내용 다시 전달
+			ObjectMapper mapper = new ObjectMapper();
+			
+			model.addAttribute("bContent", bContent);
+			model.addAttribute("bTitle", dto.getbTitle());
+			model.addAttribute("bAddress", dto.getbAddress());
+			model.addAttribute("tagJsonList", dto.getTags());
+			model.addAttribute("jsKey", kakao.getJsKey());
+			
+			// 자동완성 태그 목록
+			List<TagDto> allTagList = service.getAllTags();
+			String allTagJsonList = mapper.writeValueAsString(allTagList);
+			model.addAttribute("allTagJsonList", allTagJsonList);
+			
+			// 파일 업로드 요청 url
+			model.addAttribute("initRequestUrl", environmentService.getInitRequest());
+			
+			return "/board/createPage";
+		} 
+		
 		// 게시글 생성
 		boolean create = service.createBoard(dto);
 		rttr.addFlashAttribute("createResult", create ? "true" : "false");
@@ -114,7 +142,6 @@ public class BoardController {
 		
 		return "redirect:paging";
 	}
-	
 	
 	// 게시글 상세보기
 	@RequestMapping("/detailBoard")

--- a/src/main/webapp/WEB-INF/views/board/createPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/createPage.jsp
@@ -45,6 +45,11 @@
 <%-- 	<%@ include file="/WEB-INF/views/include/footer.jsp" %> --%>
 	<div id="allTagJsonList" data-allTagJsonList="${fn:escapeXml(allTagJsonList)}"></div>
 	<div class="hidden-data" id="initRequestUrl" data-initRequestUrl="${initRequestUrl}"></div>
+	<div class="hidden-data" id="errorMessage" data-errorMessage="${error}"></div>
+	<div class="hidden-data" id="errorbContent" data-errorbContent="${bContent}"></div>
+	<div class="hidden-data" id="errorbTitle" data-errorbTitle="${bTitle}"></div>
+	<div class="hidden-data" id="errorbAddress" data-errorbAddress="${bAddress}"></div>
+	<div class="hidden-data" id="errorTags" data-errortagJsonList="${fn:escapeXml(tagJsonList)}"></div>
 	
 	<script src="<c:url value="/resources/js/createPage.js"/>"></script>
 	<script src="<c:url value="/resources/js/uploadAdapter.js"/>"></script>

--- a/src/main/webapp/resources/js/createPage.js
+++ b/src/main/webapp/resources/js/createPage.js
@@ -1,4 +1,54 @@
-/* ckeditor */
+/* 태그 입력창
+================================================== */
+const tagInput = document.querySelector("#tagInput") // 실제 태그 입력창
+const allTagJsonStr = document.querySelector("#allTagJsonList").getAttribute("data-allTagJsonList")
+const allTagList = JSON.parse(allTagJsonStr)
+
+const tagify = new Tagify(tagInput, {
+  maxTags: 10,
+  // 드롭다운 자동완성 글자 수
+  dropdown: {
+    enabled: 1,
+  },
+  // ghost-text 비활성화
+  autoComplete: {
+    enabled: false
+  },
+  // 자동완성 목록
+  whitelist: allTagList
+})
+
+/* 게시글 등록 시 에러 발생하는 경우 작성했던 내용들 다시 붙여주기
+================================================== */
+const errorMessage = document.querySelector("#errorMessage").getAttribute("data-errorMessage")
+if(errorMessage){
+  alert(errorMessage)
+
+  // 게시글 제목 다시 붙여넣기
+  const errorbCTitle = document.querySelector("#errorbTitle").getAttribute("data-errorbTitle")
+  document.querySelector(".bTitleInput").value = errorbCTitle
+
+  // 게시글 내용 다시 붙여넣기
+  const errorbContent = document.querySelector("#errorbContent").getAttribute("data-errorbContent")
+  document.querySelector("#editor").innerHTML = errorbContent
+
+  // 지도 다시 붙여넣기
+  const errorbAddress = document.querySelector("#errorbAddress").getAttribute("data-errorbAddress")
+  if(errorbAddress){
+    const inputAdd = document.querySelector("#inputAdd")
+    inputAdd.value = errorbAddress
+  }
+
+  // 태그 다시 붙여넣기
+  const errortagJsonStr = document.querySelector("#errorTags").getAttribute("data-errortagJsonList")
+  if(errortagJsonStr){
+    const tagList = JSON.parse(errortagJsonStr)
+    tagify.addTags(tagList)
+  }
+}
+
+/* ckeditor
+================================================== */
 let editor;
  
  // 글 작성
@@ -20,6 +70,8 @@ function MyCustomUploadAdapterPlugin(editor) {
   }
 }
 
+/* 주소 검색
+================================================== */
 // 검색한 주소를 [input]에 set
 const searchedAdd = () => {
     new daum.Postcode({
@@ -30,22 +82,3 @@ const searchedAdd = () => {
     }).open()
 }
 
-/* 태그 입력창
-================================================== */
-const tagInput = document.querySelector("#tagInput") // 실제 태그 입력창
-const allTagJsonStr = document.querySelector("#allTagJsonList").getAttribute("data-allTagJsonList")
-const allTagList = JSON.parse(allTagJsonStr)
-
-const tagify = new Tagify(tagInput, {
-  maxTags: 10,
-  // 드롭다운 자동완성 글자 수
-  dropdown: {
-    enabled: 1,
-  },
-  // ghost-text 비활성화
-  autoComplete: {
-    enabled: false
-  },
-  // 자동완성 목록
-  whitelist: allTagList
-})


### PR DESCRIPTION
📌 변경 사항
- 게시글 내용(```bContent```)이 4000바이트를 초과하는 경우, 등록 처리를 중단하고 사용자 입력 내용을 유지한 채 다시 작성 페이지로 이동
- 등록 실패 시 작성했던 제목, 본문, 주소, 태그를 다시 입력창에 자동으로 복원하도록 처리
- 서버 측에서 ```bContent``` 길이 검사 추가 및 에러 메시지 모델에 포함

🛠️ 수정한 이유
- DB 컬럼 타입이 ```VARCHAR2(4000 BYTE)```로 제한되어 있어 이보다 큰 내용 입력 시 오류 발생
- 사용자 경험 개선을 위해 입력값 손실 없이 다시 작성할 수 있도록 보완

🔍 주요 변경 파일
- BoardController.java
- createPage.js
- createPage.jsp

✅ 테스트 내용
- [x] 4000바이트 초과 시 에러 메시지 출력 및 입력값 유지 확인
- [x] 태그 자동완성 및 복원 정상 동작 확인
- [x] 기존 등록 기능 및 UI 이상 여부 확인

🔗 관련 이슈
closes #58 