### PR TITLE
[BUG] Kakao.init() 중복 호출 시 "Already initialized" 에러 발생

### DIFF
--- a/src/main/webapp/resources/js/fixedButton.js
+++ b/src/main/webapp/resources/js/fixedButton.js
@@ -158,14 +158,23 @@ function shareNaver() {
 	// 카카오 공유
 function shareKakao() {
 	const imgUrl = getThumbnailUrl()
-	const currentURL = window.location.href
+	const currentURL = window.location.href // 쿼리 포함한 전체 URL
+	const origin = window.location.origin // 현재 도메인 + 프로토콜만 추출 (예: https://yourdomain.com)
 	getKakaoKey()
 		.then(kakaoKey => {
-			Kakao.init(kakaoKey)
+			// 초기화가 안되었을 때만 초기화
+			if(!Kakao.isInitialized()) {
+				Kakao.init(kakaoKey) 
+			}
+			
 			Kakao.Link.sendDefault({
 				objectType: 'feed',
+				itemContent: {
+					profileText: 'HomeTalk',
+					profileImageUrl: `${origin}/resources/images/logo2.png`
+				},
 				content: {
-					title: 'test20',
+					title: '',
 					description: bTitle,
 					imageUrl: imgUrl,
 					link: {


### PR DESCRIPTION
## 📌 변경 사항
- ```shareKakao``` 함수 내 ```Kakao.init()``` 호출 시 중복 초기화 방지 코드 추가
- ```Kakao.isInitialized()```로 초기화 여부 체크 후 ```Kakao.init()``` 실행

## 🛠️ 수정한 이유
- ```Kakao.init()```을 여러 번 호출하면 ```Already initialized``` 에러가 발생하여 공유 기능이 정상 동작하지 않음
- SDK 초기화는 한 번만 수행하도록 하여 안정성 확보

## 🔍 주요 변경 파일
- fixedButton.js

## ✅ 테스트 내용
- [x] 공유 버튼 클릭 시 정상적으로 공유 메시지 전송됨
- [x] 중복 초기화 에러(Already initialized) 발생하지 않음
- [x] 기존 공유 기능 정상 작동 확인

## 🔗 관련 이슈
closes #60 
