### PR TITLE
[BUG] 게시글, 댓글, 좋아요 목록에서 작성자 닉네임이 null로 표시되는 문제 수정

### DIFF
--- a/src/main/resources/mappers/Usermapper.xml
+++ b/src/main/resources/mappers/Usermapper.xml
@@ -46,8 +46,11 @@
 	</select>
 	
 	<select id="getUserPosts" parameterType="java.util.HashMap" resultType="BoardDto">
-		SELECT * 
-		  FROM mvc_board6
+		SELECT 
+			b.*,
+			u.unickName 
+		  FROM mvc_board6 b
+		  JOIN mvc_login6 u ON b.bName = u.userId
 		 WHERE bName = #{userId}
 		   AND bStep = 0
 		   AND bIndent = 0
@@ -68,18 +71,26 @@
 	</select>
 	
 	<select id="getUserComments" resultType="BoardDto">
-		SELECT * 
-		  FROM mvc_board6
-		 WHERE bName = #{userId} 
-		   AND bStep >= 1
-		  ORDER BY bId DESC 
+		SELECT 
+			b.*,
+			u.unickname 
+		  FROM mvc_board6 b
+		  JOIN mvc_board6 o ON b.bGroup = o.bId AND o.bStep = 0
+		  JOIN mvc_login6 u ON o.bName = u.userId
+		 WHERE b.bName = #{userId}
+		   AND b.bStep >= 1
+		 ORDER BY b.bId DESC 
 	</select>
 	
 	<select id="getUserLikedPosts" resultType="BoardDto">
-		SELECT b.*
+		SELECT 
+			b.*,
+			u.unickname
 		  FROM mvc_board6 b
 		  JOIN mvc_like6 l ON b.bId = l.bId
+		  JOIN mvc_login6 u ON b.bName = u.userId
 		 WHERE l.userId = #{userId}
+		 ORDER BY b.bId DESC
 	</select>
 	
 	<select id="isOldPasswordCorrect" parameterType="java.util.HashMap" resultType="Integer">

--- a/src/main/webapp/WEB-INF/views/user/getUserComments.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getUserComments.jsp
@@ -23,7 +23,7 @@
 						<thead>
 							<tr>
 								<th>No.</th>
-								<th>작성자</th>
+								<th>게시글 작성자</th>
 								<th>댓글</th>
 								<th>작성일</th>
 							</tr>

--- a/src/main/webapp/WEB-INF/views/user/getUserLikedPosts.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getUserLikedPosts.jsp
@@ -24,7 +24,7 @@
 						<thead>
 							<tr>
 								<th>No.</th>
-								<th>작성자</th>
+								<th>게시글 작성자</th>
 								<th>제목</th>
 								<th>작성일</th>
 							</tr>

--- a/src/main/webapp/resources/css/getUserPosts.css
+++ b/src/main/webapp/resources/css/getUserPosts.css
@@ -151,8 +151,8 @@
 
 	/* '작성자' 열 */
 .my-posts-table tbody td:nth-child(2) {
-    width: 7rem;
-    text-align: left;
+    width: 10rem;
+/*     text-align: left; */
 }
 
 	/* '제목' 열 */


### PR DESCRIPTION
## 📌 변경 사항
- 마이페이지에서 내가 작성한 게시글, 댓글, 좋아요한 게시글 목록에서 작성자 닉네임이 ```null```로 표시되던 문제를 수정
- 각 조회 쿼리에 작성자 아이디와 ```mvc_login6``` 테이블을 ```JOIN```하여 닉네임(```unickname```)을 함께 조회하도록 변경
- 댓글 목록의 경우, 댓글 작성자 대신 **원글 작성자의 닉네임**을 표시하도록 쿼리 수정

## 🛠️ 수정한 이유
- 기존 ```JSP```에서는 ```${dto.unickname}```을 통해 작성자 닉네임을 표시하도록 되어 있었으나, ```DTO```에 ```unickname``` 값이 포함되지 않아 ```null```로 출력됨
- 쿼리에서 작성자 정보를 가져오지 않아 ```DTO```에 값이 담기지 않았던 것이 원인
- 사용자 경험 개선 및 데이터 일관성을 위해 닉네임 정보를 정확히 표시할 수 있도록 수정함

## 🔍 주요 변경 파일
- Usermapper.xml
- getUserComments.jsp: 로그인 사용자를 의미하는 것으로 오해될 수 있어, 실제 게시글을 작성한 사용자를 명확히 나타내기 위해 '게시글 작성자'로 수정
- getUserLikedPosts.jsp: 같은 이유로 '작성자'를 '게시글 작성자'로 변경
- getUserPosts.css: 작성자 컬럼 너비 조정

## ✅ 테스트 내용
- [x] 게시글 목록에서 작성자 닉네임이 정상적으로 표시되는지 확인
- [x] 댓글 목록에서 원글 작성자의 닉네임이 표시되는지 확인
- [x] 좋아요한 게시글에서 작성자 닉네임이 정상 출력되는지 확인
- [x] 기존 기능에 영향 없는지 테스트

## 🔗 관련 이슈
closes #62 