### PR TITLE
[BUG] 웹소캣 연결 끊김 및 오류

### DIFF
--- a/src/main/java/com/my/ex/server/ChatServer.java
+++ b/src/main/java/com/my/ex/server/ChatServer.java
@@ -6,6 +6,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
 import javax.websocket.OnMessage;
 import javax.websocket.OnOpen;
 import javax.websocket.Session;
@@ -116,6 +118,21 @@ public class ChatServer {
 				}
 			}
 		}
+	}
+	
+	@OnClose
+	public void handleClose(Session session) {
+		System.out.println("웹소켓 세션 닫힘: " + session.getId());
+		sessionList.remove(session);
+		checkSessionList();
+	}
+	
+	@OnError
+	public void handleError(Throwable throwable, Session session) {
+		System.out.println("웹소켓 에러 발생: " + session.getId());
+		throwable.printStackTrace();
+		sessionList.remove(session);
+		checkSessionList();
 	}
 	
 	// 접속자를 확인하는 메서드

--- a/src/main/webapp/resources/js/directChat.js
+++ b/src/main/webapp/resources/js/directChat.js
@@ -134,7 +134,8 @@ const print = (name, msg, side, state, time) => {
 
 /* 웹소캣
 ================================================== */
-let ws = ''
+// let ws = ''
+let ws = null
 window.connect2 = (roomId, otherUserId, userId) => {
 	const msg = document.querySelector("#msg")
 	const serverUrl = document.querySelector("#serverUrl").getAttribute("data-serverUrl")
@@ -195,10 +196,13 @@ window.connect2 = (roomId, otherUserId, userId) => {
 		}
 
 		// 웹소캣 종료
-		window.addEventListener('beforeunload', function(event){
-			event.preventDefault()
-			disconnect()
-		})
+		ws.onclose = (event) => {
+			log(`웹소켓 연결 종료. 코드: ${event.code}, 이유: ${event.reason}`)
+			// 재연결 시도 로직 (3초 후 재연결)
+			setTimeout(() => {
+				window.connect2(roomId, otherUserId, userId)
+			}, 3000)
+		}
 
 		// 메시지 전송
 		window.handleKeyDown = (event) => {
@@ -217,14 +221,18 @@ window.connect2 = (roomId, otherUserId, userId) => {
 					message.code = '4'
 				}
 
-				ws.send(JSON.stringify(message))
-				msg.value = ''
-				msg.focus()
+				if(ws && ws.readyState == WebSocket.OPEN){
+					ws.send(JSON.stringify(message))
+					msg.value = ''
+					msg.focus()
 
-				if(message.code == '3') {
-					print(unickName, message.content, 'me', 'msg', message.regTime)	
-				} else if(message.code == '4') {
-					printEmotion(unickName, '고양이', 'me', 'msg', message.regTime)	
+					if(message.code == '3') {
+						print(unickName, message.content, 'me', 'msg', message.regTime)	
+					} else if(message.code == '4') {
+						printEmotion(unickName, '고양이', 'me', 'msg', message.regTime)	
+					}
+				} else {
+					log("메시지를 보낼 수 없습니다. 웹소캣이 열려있지 않습니다.")
 				}
 			}
 		}


### PR DESCRIPTION
📌 변경 사항
- **웹소켓 연결 URL 변경**: 운영 환경에서 웹소켓 연결 시 사용되는 URL에 ```www``` 서브도메인을 추가
- **클라이언트 웹소켓 재연결 로직 추가**: 웹소켓 연결이 끊어졌을 때 자동으로 재연결을 시도하는 기능을 구현
- **클라이언트 웹소켓 상태 확인 강화**: 메시지 전송 전에 웹소켓 연결 상태를 확인하는 로직을 추가
- **서버 웹소켓 에러 및 종료 처리 추가**: 서버 측 ```ChatServer.java```에 ```@OnClose``` 및 ```@OnError``` 핸들러를 추가하여 웹소켓 세션 관리 기능을 강화

🛠️ 수정한 이유
- 운영 환경에서 발생하던 웹소켓 연결 불안정 문제를 해결하기 위해
- **도메인 불일치 해소**: 서비스 접근 시 ```www``` 서브도메인으로 강제되는 환경에서, 웹소켓 연결만 기본 도메인을 사용하면서 발생할 수 있었던 ```CORS``` 또는 도메인 불일치 문제를 해결했음. 이는 초기 웹소켓 연결 실패(```WebSocket connection failed```)의 주요 원인이었음.
- **연결 끊김 오류 방지**: ```java.io.EOFException```과 ```WebSocket is already in CLOSING or CLOSED state``` 오류는 주로 서버 또는 네트워크 문제로 인해 웹소켓 연결이 예기치 않게 끊어졌을 때 발생함. 클라이언트의 자동 재연결 로직과 메시지 전송 전 상태 확인을 통해 이러한 오류 발생을 줄이고, 연결 복원력을 높임.
- **서버 측 안정성 및 디버깅 개선**: 서버의 ```@OnClose```, ```@OnError``` 핸들러 추가는 웹소켓 세션이 어떤 이유로든 종료되거나 에러가 발생했을 때, 서버가 이를 감지하고 적절히 처리하며, 상세한 로그를 남겨 향후 문제 발생 시 원인 분석을 용이하게 함.

🔍 주요 변경 파일
- application.properties
- ChatServer.java
- directChat.js

✅ 테스트 내용
- [x] 웹소켓 연결 및 메시지 송수신 동작 확인
- [x] 기존 기능에 영향 없는지 확인
- [x] 채팅 메시지 출력 및 연결 상태 메시지 등 UI 정상 표시 확인

🔗 관련 이슈
closes #64 