### PR TITLE
[BUG] 게시글 상세 페이지 진입 시 bName 파라미터 누락으로 인한 400 오류 발생

### DIFF
--- a/src/main/webapp/resources/js/pagingList.js
+++ b/src/main/webapp/resources/js/pagingList.js
@@ -354,7 +354,7 @@ const updateSortedByHits = (pagingList, paging) => {
 							</div>
 						</footer>
 					</figcaption>
-					<a href="/board/detailBoard?bId=${dto.bId}&bGroup=${dto.bGroup}&page=${paging.page}"></a>
+					<a href="/board/detailBoard?bId=${dto.bId}&bGroup=${dto.bGroup}&page=${paging.page}&bName=${dto.bName}"></a>
 				</figure>
 	  		`
 	})


### PR DESCRIPTION
## 📌 변경 사항
- 게시글 상세 페이지 이동 시 ```bName``` 파라미터가 누락되지 않도록 링크 생성 로직 수정

## 🛠️ 수정한 이유
- 게시글 목록에서 정렬 변경 또는 페이지 이동 후, 상세 페이지로 이동할 때 ```bName``` 파라미터가 누락되어 ```400 Bad Request```가 발생
- 서버에서 게시글 상세 조회 시 필수로 요구하는 ```bName``` 값이 포함되지 않아 예외가 발생하던 문제 해결을 위해 수정함

## 🔍 주요 변경 파일
- pagingList.js

## ✅ 테스트 내용
- [x] 정렬/페이지 이동 후에도 게시글 상세 페이지 정상 진입 확인
- [x]  기존 목록/정렬 기능에 영향 없는지 확인
- [x]  게시글 상세 정보 정상 출력 및 에러 미발생 확인

## 🔗 관련 이슈
closes #66 
