### PR TITLE
[BUG] 게시글 내용(bContent) 내 HTML 이스케이프 미처리로 인한 이미지 일부 미노출 문제

### DIFF
--- a/src/main/webapp/WEB-INF/views/board/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detailPage.jsp
@@ -369,7 +369,7 @@
 	<div class="hidden-data" id="updateResult" data-update-result="${updateResult}"></div>
 	<div class="hidden-data" id="bId" data-bId="${dto.bId}"></div>
 	<div class="hidden-data" id="bTitle" data-bTitle="${dto.bTitle}"></div>
-	<div class="hidden-data" id="bContent" data-bContent='${dto.bContent}'></div>
+	<div class="hidden-data" id="bContent" data-bContent="<c:out value='${dto.bContent}'/>"></div>
 	<div class="hidden-data" id="isLiked" data-isLiked="${isLiked}"></div>
 	<div class="hidden-data" id="isBookmarked" data-isBookmarked="${isBookmarked}"></div>
 	<div class="hidden-data" id="userNickname" data-userId="${sessionScope.userNickname}"></div>


### PR DESCRIPTION
## 📌 변경 사항
- ```detailPage.jsp``` 내 ```bContent``` 데이터를 삽입하는 부분을 ```<c:out>``` 태그로 감싸 ```HTML``` 이스케이프 처리 적용
- ```fixedButton.js```에서 ```window.bContent```에 정상적으로 이스케이프된 데이터를 할당하도록 수정

## 🛠️ 수정한 이유
- 이스케이프 미처리로 인해 ```bContent``` 내 이미지 태그가 일부만 렌더링되는 문제 해결
- 이미지 갤러리에서 모든 이미지가 정상적으로 노출되도록 하기 위함

## 🔍 주요 변경 파일
- detailPage.jsp

## ✅ 테스트 내용
- [x] 게시글 상세 페이지 이미지 갯수 및 갤러리 정상 표시 확인
- [x] 다양한 게시글 텍스트+이미지 혼합 상태에서 동작 테스트 완료
- [x] 기존 기능 및 UI 정상 작동 확인

## 🔗 관련 이슈
closes #68 