### PR TITLE
[BUG] 파일명 공백으로 인한 file not found 에러 해결

### DIFF
--- a/src/main/java/com/my/ex/controller/UserController.java
+++ b/src/main/java/com/my/ex/controller/UserController.java
@@ -2,6 +2,8 @@ package com.my.ex.controller;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +14,8 @@ import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -271,31 +275,27 @@ public class UserController {
 	public void getProfileFilename(@PathVariable String bName) {
 		System.out.println("getProfileFilename 호출");
 		System.out.println("bName: " + bName);
-//		String filename = service.getProfileFilename(bName);
-//		return filename;
 	}
 	
 	// 프로필 이미지 파일 서빙
 	@RequestMapping("/getProfileImage/{filename:.+}")
 	@ResponseBody
 	public Resource getProfileImage(@PathVariable String filename) {
-//		String uploadDir = "C:\\server_program\\profileImgTest\\";
 		String uploadDir = environmentService.getProfileUploadPath();
 		File file = new File(uploadDir, filename);
 		
 		if (file.exists()) {
 			return new FileSystemResource(file); // file자체를 보내는 것은 X, HTTP 본문 응답으로 자동 변환해주는 API(FileSystemResource())를 이용해서 보내야 함
 		} else {
-			throw new RuntimeException("File not found");
+			throw new RuntimeException("File not found: " + file.getAbsolutePath());
 		}
 	}
 	
 	// 파일 저장
 	private String saveProfileImage(MultipartFile profileImage, String userId) throws IOException {
 		// 파일 저장 경로 설정
-//		String uploadDir = "C:\\server_program\\profileImgTest\\";
 		String uploadDir = environmentService.getProfileUploadPath();
-		String filename = userId + "_" + profileImage.getOriginalFilename();
+		String filename = userId + "_" + profileImage.getOriginalFilename().trim().replace(" ", "_"); 
 		File fileToSave = new File(uploadDir, filename);
 		
 		// 파일 저장


### PR DESCRIPTION
## 📌 변경 사항
- 프로필 이미지 파일명이 공백을 포함하는 경우, 서버에서 `file not found` 에러가 발생하는 문제를 해결
- 파일명을 처리할 때 `.trim().replace(" ", "_")`를 적용하여 공백을 `_`로 대체하도록 수정
- DB에 저장된 파일명도 공백을 `_`로 대체하여 서버에서 정확한 파일을 찾을 수 있도록 함

## 🛠️ 수정한 이유
- 프로필 이미지 파일명에 공백이 포함되어 서버에서 파일을 찾을 수 없었고, 이로 인해 UI에서는 정상적으로 표시되지만 서버에서 `file not found` 에러가 발생하는 문제가 발생
- 파일명을 처리하여 서버에서 이미지 파일을 올바르게 가져올 수 있도록 하기 위해 수정

## 🔍 주요 변경 파일
- UserController.java

## ✅ 테스트 내용
- [x] 기능 동작 확인: 공백이 포함된 파일명도 정상적으로 서버에서 찾아서 이미지가 표시되는지 확인
- [x] 기존 기능 영향 없는지 확인: 다른 파일명이나 기존 코드가 정상적으로 동작하는지 확인
- [x] UI 정상 표시 확인: 공백 처리된 이미지가 UI에 정상적으로 표시되는지 확인

## 🔗 관련 이슈
closes #73 