### PR TITLE
[ENH] 메신저 대화 목록 최신 순으로 정렬되지 않는 문제

### DIFF
--- a/src/main/java/com/my/ex/controller/ChatController.java
+++ b/src/main/java/com/my/ex/controller/ChatController.java
@@ -47,22 +47,21 @@ public class ChatController {
 	@RequestMapping("/getRoomList")
 	public Map<String, Object> getRoomList(@RequestParam String userId,
 										 @RequestParam(value = "searchText", required = false, defaultValue = "") String searchText) {
-		List<String> roomIdList = service.getRoomId(userId); // roomId만 가져오기
-		
+		List<MessageDto> messageDtos = service.getLastMessagesByUserId(userId, searchText);
 		List<ChatRoomDto> lastMessageList = new ArrayList<>(); // 마지막 메시지들만 담을 List<>
-		for(String roomId : roomIdList) { // roomId 한개씩 꺼내기
-			MessageDto messageDto = service.getLastMessage(roomId, searchText); // roomId, 검색어 주고 마지막 메시지 가져오기
-			if(messageDto != null) { // 대화내용이 있다면
-				messageDto.setRoomId(roomId);
-				String receiver = service.getReceiver(roomId, userId, messageDto.getSender());
+		
+		if(messageDtos != null) {
+			for(MessageDto messageDto  : messageDtos) {
+				System.out.println(messageDto.getRoomId());
+				String receiver = service.getReceiver(messageDto.getRoomId(), userId, messageDto.getSender());
 				String receiverNickname = messageService.getNicknameByUserId(receiver);
-				int unreadMessageCount = service.getUnreadMessageCount(roomId, userId);
+				int unreadMessageCount = service.getUnreadMessageCount(messageDto.getRoomId(), userId);
 				String filename = userService.getProfileFilename(receiver);
 				String imageUrl = "/user/getProfileImage/" + filename;
 				
 				// 목록에 보여줄 정보
-				ChatRoomDto dto = new ChatRoomDto(messageDto, receiver, receiverNickname, imageUrl, unreadMessageCount);
-				lastMessageList.add(dto);
+				ChatRoomDto chatRoomDto = new ChatRoomDto(messageDto, receiver, receiverNickname, imageUrl, unreadMessageCount);
+				lastMessageList.add(chatRoomDto);
 			}
 		}
 		

--- a/src/main/java/com/my/ex/dao/ChatDao.java
+++ b/src/main/java/com/my/ex/dao/ChatDao.java
@@ -32,11 +32,6 @@ public class ChatDao implements IChatDao {
 	}
 
 	@Override
-	public MessageDto getLastMessage(Map<String, String> map) {
-		return session.selectOne(NAMESPACE + "getLastMessage", map);
-	}
-
-	@Override
 	public String getReceiver(Map<String, String> map) {
 		return session.selectOne(NAMESPACE + "getReceiver", map);
 	}
@@ -49,6 +44,11 @@ public class ChatDao implements IChatDao {
 	@Override
 	public void setIsRead(Map<String, String> map) {
 		session.update(NAMESPACE + "setIsRead", map);
+	}
+
+	@Override
+	public List<MessageDto> getLastMessagesByUserId(Map<String, String> map) {
+		return session.selectList(NAMESPACE + "getLastMessagesByUserId", map);
 	}
 
 }

--- a/src/main/java/com/my/ex/dao/IChatDao.java
+++ b/src/main/java/com/my/ex/dao/IChatDao.java
@@ -9,8 +9,8 @@ public interface IChatDao {
 	int getUnreadMessageTotalCount(String receiver);
 	List<MessageDto> getChatHistory(String roomId);
 	List<String> getRoomId(String userId);
-	MessageDto getLastMessage(Map<String, String> map);
 	String getReceiver(Map<String, String> map);
 	int getUnreadMessageCount(Map<String, String> map);
 	void setIsRead(Map<String, String> map);
+	List<MessageDto> getLastMessagesByUserId(Map<String, String> map);
 }

--- a/src/main/java/com/my/ex/service/ChatService.java
+++ b/src/main/java/com/my/ex/service/ChatService.java
@@ -32,14 +32,6 @@ public class ChatService implements IChatService {
 	}
 
 	@Override
-	public MessageDto getLastMessage(String roomId, String searchText) {
-		Map<String, String> map = new HashMap<>();
-		map.put("roomId", roomId);
-		map.put("searchText", searchText);
-		return dao.getLastMessage(map);
-	}
-
-	@Override
 	public String getReceiver(String roomId, String userId, String sender) {
 		Map<String, String> map = new HashMap<>();
 		map.put("roomId", roomId);
@@ -61,6 +53,15 @@ public class ChatService implements IChatService {
 	@Override
 	public void setIsRead(Map<String, String> map) {
 		dao.setIsRead(map);
+	}
+
+	@Override
+	public List<MessageDto> getLastMessagesByUserId(String userId, String searchText) {
+		Map<String, String>map = new HashMap<>();
+		map.put("userId", userId);
+		map.put("searchText", searchText);
+		
+		return dao.getLastMessagesByUserId(map);
 	}
 
 }

--- a/src/main/java/com/my/ex/service/IChatService.java
+++ b/src/main/java/com/my/ex/service/IChatService.java
@@ -9,8 +9,8 @@ public interface IChatService {
 	int getUnreadMessageTotalCount(String receiver);
 	List<MessageDto> getChatHistory(String roomId);
 	List<String> getRoomId(String userId);
-	MessageDto getLastMessage(String roomId, String searchText);
 	String getReceiver(String roomId, String userId, String sender);
 	int getUnreadMessageCount(String roomId, String userId);
 	void setIsRead(Map<String, String> map);
+	List<MessageDto> getLastMessagesByUserId(String userId, String searchText);
 }

--- a/src/main/resources/mappers/Messagemapper.xml
+++ b/src/main/resources/mappers/Messagemapper.xml
@@ -3,6 +3,9 @@
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.my.ex.MessageMapper">
+	<resultMap id="messageResultMap" type="MessageDto">
+	    <result property="roomId" column="room_id"/>
+	</resultMap>
 
 	<select id="findRoomId" parameterType="java.util.HashMap" resultType="String">
 		SELECT DISTINCT room_Id
@@ -18,23 +21,29 @@
 		    OR receiver = #{userId}
 	</select>
 	
-	<!-- 마지막 대화 내용 조회 -->
-	<select id="getLastMessage" parameterType="java.util.HashMap" resultType="MessageDto">
+	<!-- 채팅방 목록에 표시할 마지막 메시지(요약용)를 각 채팅방별로 가져옴 -->
+	<select id="getLastMessagesByUserId" parameterType="java.util.HashMap" resultMap="messageResultMap">
 		SELECT *
 		  FROM (
-		       SELECT DISTINCT *
-		         FROM mvc_chat6
-		        WHERE room_id = #{roomId}
-		        <if test="searchText != null and searchText != ''">
-		        	AND (
-						content LIKE '%' || #{searchText} || '%'
-						OR receiver LIKE '%' || #{searchText} || '%'
-						OR sender LIKE '%' || #{searchText} || '%'		        	
-		        	)
-		        </if>
-		     ORDER BY message_id DESC
-          )
-		 WHERE ROWNUM = 1
+		     SELECT 
+		     	m.*,
+		        ROW_NUMBER() OVER (PARTITION BY room_id ORDER BY regdate DESC, regtime DESC) AS rn
+		       FROM mvc_chat6 m
+		      WHERE m.room_id IN (
+		      	  SELECT room_id
+		      		FROM mvc_chat6
+		      	   WHERE sender = #{userId} OR receiver = #{userId}
+		      )
+		      <if test="searchText != null and searchText != ''">
+		          AND (
+			  		  content LIKE '%' || #{searchText} || '%'
+					  OR receiver LIKE '%' || #{searchText} || '%'
+					  OR sender LIKE '%' || #{searchText} || '%'		        	
+		          )
+	          </if>
+		   )
+		 WHERE rn = 1
+		 ORDER BY regdate DESC, regtime DESC
 	</select>
 	
 	<!-- 대화 상대방이 누군지 조회 -->
@@ -104,15 +113,7 @@
 			)
 	</insert>
 	
-	<!-- 과거 대화내용 불러오기 -->
-	<select id="getPastMessages1" resultType="MessageDto">
-		SELECT *
-		  FROM mvc_chat6
-		 WHERE room_id = #{roomId}
-	  ORDER BY message_id  
-	</select>
-	
-	<!-- 과거 대화내용 불러오기 -->
+	<!-- 특정 채팅방의 이전 채팅 내역(스크롤로 불러오기 등)을 가져오기 -->
 	<select id="getPastMessages" resultType="MessageDto">
 		SELECT 
 			c.*,


### PR DESCRIPTION
## 📌 변경 사항
- 메신저 대화 목록을 불러올 때, 최신 대화순으로 정렬되도록 수정
- 쿼리에서 `PARTITION BY`를 사용하여, 채팅방 별로 구분된 데이터를 처리한 후, 각 그룹 내에서 최신 메시지를 추출해내는 방식으로 구현 

## 🛠️ 수정한 이유
- 기존에는 대화 목록이 임의의 순서로 불러와졌기 때문에, 사용자가 최신 대화를 찾는 데 불편함

## 🔍 주요 변경 파일
- ChatController.java
- ChatDao.java
- ChatService.java
- Messagemapper.xml

## ✅ 테스트 내용
- [x] 대화 목록이 최신 대화순으로 정렬되어 표시되는지 확인
- [x] 다른 기능이 정상적으로 동작하는지 확인
- [x] UI에서 최신 대화가 가장 상단에 표시되는지 확인

## 🔗 관련 이슈
closes #74 