### PR TITLE
[FEAT] 답글 작성 시 댓글 작성자에게 알림 전송 기능 추가

### DIFF
--- a/src/main/java/com/my/ex/controller/BoardController.java
+++ b/src/main/java/com/my/ex/controller/BoardController.java
@@ -379,11 +379,11 @@ public class BoardController {
 	// 댓글 등록
 	@ResponseBody
 	@RequestMapping(value = "/replyInsert", method = RequestMethod.POST)
-	public Map<String, Object> replyInsert(@RequestParam(value = "page", required = false, defaultValue = "1") int page,
+	public Map<String, Object> replyInsert(@RequestParam(value = "page", required = false, defaultValue = "1") int commentPage,
 										   @RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
+										   @RequestParam String boardWriterId,
 										   HttpSession session,
-										   BoardDto dto,
-										   @RequestParam String boardWriterId) {
+										   BoardDto dto) {
 		String userId = (String)session.getAttribute("userId");
 		dto.setbName(userId); // 댓글 작성자ID (알림을 발생시킨 사용자ID)
 		
@@ -393,10 +393,10 @@ public class BoardController {
 		notificationDto.setType("COMMENT");
 		notificationDto.setSenderId(userId); // 알림을 발생시킨 사용자ID
 		
-		service.replyInsert(dto, notificationDto, page);
+		service.replyInsert(dto, notificationDto, commentPage);
 		
 		int commentsCount = service.incrementCommentCount(dto.getbGroup());
-		CommentsListResponse response = commentsPagingAjax(page, sortType, dto.getbGroup(), session);
+		CommentsListResponse response = commentsPagingAjax(commentPage, sortType, dto.getbGroup(), session);
 		Map<String, Object> map = new HashMap<>();
 		map.put("commentsCount", commentsCount);
 		map.put("commentsListResponse", response);
@@ -407,18 +407,28 @@ public class BoardController {
 	// 답글 등록
 	@ResponseBody
 	@RequestMapping(value = "/replyChildInsert", method = RequestMethod.POST)
-	public Map<String, Object> replyChildInsert(@RequestParam(value = "page", required = false, defaultValue = "1") int page,
+	public Map<String, Object> replyChildInsert(@RequestParam(value = "page", required = false, defaultValue = "1") int commentPage,
 										  		@RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
-										  		HttpSession session, BoardDto dto) {
+										  		@RequestParam String commentWriterId,
+										  		HttpSession session, 
+										  		BoardDto dto) {
 		String userId = (String)session.getAttribute("userId");
 		dto.setbName(userId);
-		service.replyChildInsert(dto);
+		
+		// 알림 정보 넘김
+		NotificationDto notificationDto = new NotificationDto();
+		notificationDto.setUserId(commentWriterId); // 알림을 받을 사용자ID(댓글 작성자)
+		notificationDto.setType("CHILD_COMMENT");
+		notificationDto.setSenderId(userId); // 알림을 발생시킨 사용자ID(답글 작성자)
+		
+		service.replyChildInsert(dto, notificationDto, commentPage);
 		
 		int commentsCount = service.incrementCommentCount(dto.getbGroup());
-		CommentsListResponse response = commentsPagingAjax(page, sortType, dto.getbGroup(), session);
+		CommentsListResponse response = commentsPagingAjax(commentPage, sortType, dto.getbGroup(), session);
 		Map<String, Object> map = new HashMap<>();
 		map.put("commentsCount", commentsCount);
 		map.put("commentsListResponse", response);
+		
 		return map;
 	}
 	
@@ -600,6 +610,7 @@ public class BoardController {
 			@RequestParam(value = "sortType", required = false, defaultValue = "latest") String sortType,
 			int bGroup,
 			HttpSession session) {
+		
 		// 'page', 'sortType' 값이 없는 경우 지정해주어야하는데, fetch로 보내면 @RequestParam을 사용못하기때문에 $.ajax로 요청하고 @RequestParam을 사용 
 		List<BoardDto> commentsPagingList = service.commentsPagingList(currentcommentPage, sortType, bGroup);
 		

--- a/src/main/java/com/my/ex/service/BoardService.java
+++ b/src/main/java/com/my/ex/service/BoardService.java
@@ -159,8 +159,34 @@ public class BoardService implements IBoardService {
 	}
 
 	@Override
-	public void replyChildInsert(BoardDto dto) {
+	public void replyChildInsert(BoardDto dto, NotificationDto notificationDto, int commentPage) {
 		dao.replyChildInsert(dto);
+		
+		// 답글 작성자와 댓글 작성자가 다를 경우에만 알림 생성
+		if(!notificationDto.getUserId().equals(notificationDto.getSenderId())) {
+			int childCommentId = dto.getbId(); // 답글 삽입 후 set된 답글ID
+			
+			String childCommentSnippet = dto.getbContent().length() > 10 ? dto.getbContent().substring(0, 10) + "..." : dto.getbContent();
+			ObjectMapper mapper = new ObjectMapper();
+			String dataJson = null;
+			try {
+				Map<String, Object> map = new HashMap<>();
+				map.put("childcommentPage", "1");
+				map.put("childcommentSnippet", childCommentSnippet);
+				dataJson = mapper.writeValueAsString(map);
+			} catch (JsonProcessingException e) {
+				e.printStackTrace();
+			}
+			notificationDto.setDataJson(dataJson);
+			
+			notificationDto.setRelatedId(childCommentId);
+			notificationDto.setLink("/board/detailBoard?"
+					+ "bId=" + dto.getbGroup()
+					+ "&bGroup=" + dto.getbGroup() 
+					+ "&bName=" + notificationDto.getUserId() // 알림을 받을 사용자ID(게시글 작성자ID)
+					+ "&targetCommentId=" + childCommentId);
+			notificationService.addNotification(notificationDto);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/my/ex/service/IBoardService.java
+++ b/src/main/java/com/my/ex/service/IBoardService.java
@@ -41,7 +41,7 @@ public interface IBoardService {
 	
 	// 댓글 및 답글 등록, 삭제
 	void replyInsert(BoardDto dto, NotificationDto notificationDto, int commentPage);
-	void replyChildInsert(BoardDto dto);
+	void replyChildInsert(BoardDto dto, NotificationDto notificationDto, int commentPage);
 	int incrementCommentCount(int bGroup);
 	int decrementCommentCount(int bGroup);
 	boolean removeReply(Map<String, Object> map);

--- a/src/main/resources/mappers/Boardmapper.xml
+++ b/src/main/resources/mappers/Boardmapper.xml
@@ -213,6 +213,10 @@
 	</select>
 	
 	<insert id="replyChildInsert" parameterType="BoardDto">
+		<selectKey keyProperty="bId" resultType="Integer" order="BEFORE">
+			SELECT seq_mvc_board6.NEXTVAL
+			  FROM dual
+		</selectKey>
 		INSERT INTO mvc_board6
 			 (
 			 bId,
@@ -224,7 +228,7 @@
 			 )
 		VALUES
 			 (
-			 seq_mvc_board6.nextval,
+			 #{bId},
 			 #{bName},
 			 #{bContent},
 			 #{bGroup},

--- a/src/main/webapp/WEB-INF/views/board/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detailPage.jsp
@@ -213,11 +213,13 @@
 												<p class="post-content removeMessage">${comment.bContent}</p>
 											</c:when>
 											<c:otherwise>
+												<!-- 정상적인 댓글이라면 -->
 												<div class="user-info">
 													<div class="left-info">
 															<img id="profile-photo-${comment.bId}" src="${profileImageUrls[status.index]}" />
 														<span class="author-name"><a href="#">${comment.unickName}</a></span>
 													</div>
+													<!-- 본인이 작성한 댓글이라면 삭제 버튼 보여줌 -->
 													<c:if test="${comment.bName == sessionScope.userId}">
 														<button type="button" class="button-filled-primary comment-remove"
 															data-comment-remove-bId="${comment.bId}"
@@ -231,13 +233,16 @@
 												</div>
 												<p class="post-content">${comment.bContent}</p>
 												<time class="post-time">${comment.bDate}</time>
+												<!-- 답글 달기 버튼 -->
 												<button type="button" class="button-filled-primary comment-child-btn"
 													data-bGroup="${comment.bGroup}"
 													data-bStep="${comment.bStep}"
 													data-bIndent="${comment.bIndent}"
+													data-commentWriterId="${comment.bName}"
 												>
 													답글 달기
 												</button>
+												<!--  -->
 												<button type="button" class="button-filled-primary"
 													id="thumbupButton"
 													data-recommend-bId="${comment.bId}"
@@ -468,6 +473,7 @@ const editCommentTable = (replyList, profileImageUrls) => {
 					    		data-bGroup="\${replyList[i].bGroup}"
 					    		data-bStep="\${replyList[i].bStep}"
 					    		data-bIndent="\${replyList[i].bIndent}"
+								data-commentWriterId="\${replyList[i].bName}"
 				    		> 
 					    		답글 달기
 					    	</button>
@@ -517,7 +523,7 @@ const editCommentTable = (replyList, profileImageUrls) => {
 	return output
 }
 
-	// 답글UI 업데이트
+	// 답글 입력창UI
 const replyChildUI = () => {
 	let output = `<div class="comment-input-container commentCell">
 					<input type="text" name="bContent" class="styled-input" required>
@@ -691,6 +697,7 @@ function registerEventListeners(){
 	        const bGroup = this.getAttribute('data-bGroup')
 	        const bStep = this.getAttribute('data-bStep')	
 	        const bIndent = this.getAttribute('data-bIndent')
+	        const commentWriterId = this.getAttribute('data-commentWriterId')
 	        
 	        // 새로운 입력 필드 추가
             const output = replyChildUI()
@@ -709,6 +716,7 @@ function registerEventListeners(){
                     	url: "replyChildInsert",
                     	data: {
                     		page: currentcommentPage,
+							commentWriterId: commentWriterId,
                     		bContent: bContent,
                     		bGroup: bGroup,
                     		bStep: bStep,

--- a/src/main/webapp/resources/css/detailPage.css
+++ b/src/main/webapp/resources/css/detailPage.css
@@ -690,9 +690,14 @@ span.page-link {
 /* 댓글 알림 클릭 시 해당 댓글 하이라이트
  ================================================== */
 .highlight-comment {
-	background-color: #fff8c6;
-	border-left: 4px solid #ffd54f;
+	background-color: #fff8c6 !important;
+	border-left: 4px solid #ffd54f !important;
 	transition: background-color 0.7s ease;
+}
+
+/* 답글의 자식 요소들에 적용된 배경색을 초기화 */
+.highlight-comment .comment-child {
+    background-color: transparent !important; /* 하이라이트 되는 동안 자식 요소의 배경색을 투명하게 만듦 */
 }
 
 /* 반응형 모바일

--- a/src/main/webapp/resources/js/getNotifications.js
+++ b/src/main/webapp/resources/js/getNotifications.js
@@ -62,6 +62,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     <strong class="sender-name">${notificationDto.senderId}</strong>님이 댓글을 달았습니다:<br/>
                     <span class="comment-preview-text">${commentSnippet}</span>
                 `
+            } else if(notificationDto.type == 'CHILD_COMMENT'){
+                const data = JSON.parse(notificationDto.dataJson)
+                commentSnippet = data.childcommentSnippet
+                notificationText =
+                `
+                    <strong class="sender-name">${notificationDto.senderId}</strong>님이 답글을 달았습니다:<br/>
+                    <span class="comment-preview-text">${commentSnippet}</span>
+                `
             }
 
             output += 

--- a/src/main/webapp/resources/js/loginInfo.js
+++ b/src/main/webapp/resources/js/loginInfo.js
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			// 읽음 여부 표시 클래스
 			let readClass = notificationDto.isRead == 'N'? 'unread' : ''
 
-			// type이 댓글인 경우 미리보기로 보여줄 내용
+			// type이 댓글 또는 답글인 경우 미리보기로 보여줄 내용
 			let commentSnippet = ''
 
 			// 알림 메시지
@@ -121,6 +121,19 @@ document.addEventListener('DOMContentLoaded', () => {
 				notificationText = 
 				`
 					<strong>${notificationDto.senderId}</strong>님이 새로운 댓글을 달았습니다:
+					<span class="comment-preview-text">"${commentSnippet}"</span>
+				`
+			} else if(notificationDto.type == 'CHILD_COMMENT'){
+				if(notificationDto.dataJson){
+					const parsedData = JSON.parse(notificationDto.dataJson)
+					if(parsedData.childcommentSnippet){
+						commentSnippet = parsedData.childcommentSnippet
+					}
+				}
+
+				notificationText = 
+				`
+					<strong>${notificationDto.senderId}</strong>님이 새로운 답글을 달았습니다:
 					<span class="comment-preview-text">"${commentSnippet}"</span>
 				`
 			}
@@ -200,7 +213,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						// notificationListContainer.appendChild(infoMessage)
 						
 						// 클릭 시 읽음 처리 
-						const aElements = notificationModal.querySelectorAll("notification-item a")
+						const aElements = notificationModal.querySelectorAll(".notification-item a")
 						aElements.forEach((a) => {
 							a.addEventListener('click', (event) => {
 								event.preventDefault()


### PR DESCRIPTION
## 📌 변경 사항
- 답글 작성 시 댓글 작성자에게 알림 전송 기능 추가
- 알림 타입 "`CHILD_COMMENT`" 추가 및 관련 처리 로직 구현
- 알림 테이블 제약조건에 "`CHILD_COMMENT`" 타입 허용
- 알림 렌더링 로직에 답글 알림 처리 분기 추가

## 🛠️ 수정한 이유
- 사용자가 자신이 작성한 댓글에 누가 답글을 남겼는지 알 수 있도록 하기 위함
- 기존 '좋아요', '댓글' 알림에 이어 알림 기능의 확장성 확보

## 🔍 주요 변경 파일
- BoardController.java
- BoardService.java
- Boardmapper.xml
- detailPage.jsp
- detailPage.css
- loginInfo.js

## ✅ 테스트 내용
- [x] 답글 작성 시 댓글 작성자에게 알림 전송되는지 확인
- [x] 기존 댓글, 좋아요 알림 기능과 충돌 없는지 확인
- [x] 알림 모달에서 UI 정상적으로 표시되는지 확인

## 🔗 관련 이슈
closes #84 
