### PR TITLE
[BUG] 댓글 알림 클릭 시 페이지 이동 오류 및 댓글 등록 시 원래 페이지가 유지되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/my/ex/controller/BoardController.java
+++ b/src/main/java/com/my/ex/controller/BoardController.java
@@ -173,9 +173,8 @@ public class BoardController {
 		// 만약 알림 링크를 통해 targetCommentId가 넘어왔다면, 해당 댓글의 실제 페이지를 계산
 		int actualCommentPageToLoad = 1; // 기본적으로 1페이지 로드
 		if(targetCommentId != null) {
-			int commentsPageLimit = 6; // 서비스와 동일한 값 사용
 			// 해당 targetCommentId가 현재 몇번째 페이지에 위치하는지 계산
-			actualCommentPageToLoad = service.calculateCommentPage(targetCommentId, bGroup, commentsPageLimit);
+			actualCommentPageToLoad = service.calculateCommentPage(targetCommentId, bGroup);
 		} 
 		
 		// 댓글 페이징 정보

--- a/src/main/java/com/my/ex/service/BoardService.java
+++ b/src/main/java/com/my/ex/service/BoardService.java
@@ -23,7 +23,7 @@ public class BoardService implements IBoardService {
 	// BETWEEN A AND B
 	private static final int PAGE_LIMIT = 12;  // 한 페이지에 표시할 게시글 개수
     private static final int BLOCK_LIMIT = 5;  // 하단에 표시할 페이지 번호 블록 개수 [1],[2] ..
-    private static final int COMMENTS_PAGE_LIMIT = 6;  // 한 페이지에 표시할 댓글 개수
+    public static final int COMMENTS_PAGE_LIMIT = 6;  // 한 페이지에 표시할 댓글 개수
     private static final int COMMENTS_BLOCK_LIMIT = 3;  // 하단에 표시할 페이지 번호 블록 개수 [1],[2] ..
 	
 	@Autowired
@@ -141,12 +141,12 @@ public class BoardService implements IBoardService {
 	}
 	
 	@Override
-	public int calculateCommentPage(Integer targetCommentId, int bGroup, int commentsPageLimit) {
+	public int calculateCommentPage(Integer targetCommentId, int bGroup) {
 		// targetComment가 몇번째에 위치하는지 확인
 		Map<String, Object> map = new HashMap<>();
 		map.put("targetCommentId", targetCommentId);
 		map.put("bGroup", bGroup);
-		int commentOrder = dao.getCommentOrderById(map);
+		int commentOrder = dao.getCommentOrderById(map); // 알림 발생시기와 확인시기에 댓글이 위치한 page가 다를 수 있으므로 페이지를 재계산하기 위함
 		
 		// targetComment가 위치한 페이지 링크
 		int calculatedPage =(int) Math.ceil((double)commentOrder / COMMENTS_PAGE_LIMIT);

--- a/src/main/java/com/my/ex/service/IBoardService.java
+++ b/src/main/java/com/my/ex/service/IBoardService.java
@@ -49,7 +49,7 @@ public interface IBoardService {
 	boolean removeReplyIfNoChildReplies(Map<String, Integer> map);
 	
 	// 특정 댓글 ID에 해당하는 댓글이 현재 댓글 내에서 몇 번째 페이지에 위치하는지 계산
-	int calculateCommentPage(Integer targetCommentId, int bGroup, int commentsPageLimit);
+	int calculateCommentPage(Integer targetCommentId, int bGroup);
 	
 	int getTotalBookmarks(int bId);
 	List<BoardDto> replyList(int bGroup);

--- a/src/main/resources/mappers/Boardmapper.xml
+++ b/src/main/resources/mappers/Boardmapper.xml
@@ -186,11 +186,11 @@
 	</insert>
 	
 	<select id="getCommentOrderById" parameterType="java.util.HashMap" resultType="Integer">
-		SELECT COUNT(bId) 
-		  FROM MVC_BOARD6
+		SELECT COUNT(*) + 1
+		  FROM mvc_board6
 		 WHERE bGroup = #{bGroup}
-		   AND bId <![CDATA[ >= ]]> #{targetCommentId}
 		   AND bStep > 0
+		   AND bStep <![CDATA[ < ]]> (SELECT bStep FROM mvc_board6 WHERE bId = #{targetCommentId})
 	</select>
 	
 	<update id="replyShape" parameterType="java.util.HashMap">

--- a/src/main/webapp/WEB-INF/views/board/detailPage.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detailPage.jsp
@@ -384,6 +384,7 @@
 	<div class="hidden-data" id="isBookmarked" data-isBookmarked="${isBookmarked}"></div>
 	<div class="hidden-data" id="userNickname" data-userId="${sessionScope.userNickname}"></div>
 	<div class="hidden-data" id="userId" data-userId="${sessionScope.userId}"></div>
+	<div class="hidden-data" id="commentsPageDto-page" data-commentsPageDto-page="${commentsPaging.page != null ? commentsPaging.page : 1}"></div>
 	
 	<script src="<c:url value="/resources/js/common.js"/>"></script>
 	<script src="https://developers.kakao.com/sdk/js/kakao.js"></script> <!-- 카카오 공유 -->
@@ -411,9 +412,10 @@ const setMessage = (msg) => {
 const replyBtn = document.querySelector("#commentBtn")
 const replyTable = document.querySelector(".comments")
 const replyInput = document.querySelector("#comment-input")
+const commentsPageDtoPage = parseInt(document.querySelector("#commentsPageDto-page").getAttribute("data-commentsPageDto-page"))
 const COMMENTS_PAGE_LIMIT = 6
 const COMMENTS_BLOCK_LIMIT = 3
-let currentcommentPage = 1
+let currentcommentPage = commentsPageDtoPage || 1
 
 	// 현재 페이지 블록
 const setPage = (page) => {


### PR DESCRIPTION
## 📌 변경 사항
- 댓글 알림 클릭 시 해당 댓글이 위치한 페이지를 정확히 계산하도록 `calculateCommentPage()` 쿼리 로직 수정
- 댓글/답글 작성 후에도 사용자가 머물던 댓글 페이지(`currentcommentPage`)가 유지되도록 JSP와 JS 연동 수정
- `commentsPagingDto.page` 값을 `data-*` 속성으로 JSP에 전달하고, JS에서 이를 읽어 페이지 상태 유지

## 🛠️ 수정한 이유
- 댓글 알림 클릭 후 댓글을 찾지 못하거나 잘못된 페이지로 이동하는 문제가 발생함
- 알림 댓글의 위치를 계산할 때 `bId`를 기준으로 하여 순서가 꼬이는 사례가 있었음
- 댓글/답글을 작성한 뒤에도 항상 1페이지로 이동해 사용자 경험이 떨어짐
- 알림을 통해 진입한 경우에도 페이지 상태를 정확히 반영할 필요가 있었음

## 🔍 주요 변경 파일
- BoardController.java
- BoardService.java
- Boardmapper.xml
- detailPage.jsp

## ✅ 테스트 내용
- [x] 알림 댓글 클릭 시 정확한 페이지로 이동 확인
- [x] 댓글 또는 답글 작성 후 기존 페이지에 머무르는지 확인
- [x] 기존 댓글 페이지 이동 및 렌더링 정상 동작 확인
- [x] UI 정상 표시 확인

## 🔗 관련 이슈
closes #86 
