### PR TITLE
[FEAT] 알림 전체 읽기("모두 읽기") 기능 추가

### DIFF
--- a/src/main/java/com/my/ex/controller/NotificationController.java
+++ b/src/main/java/com/my/ex/controller/NotificationController.java
@@ -97,4 +97,19 @@ public class NotificationController {
 		return responseDto;
 	}
 	
+	// 모두 읽기 처리
+	@PatchMapping("/markAllAsRead")
+	@ResponseBody
+	public NotificationResponseDto markAllAsRead(HttpSession session) {
+		String userId = (String) session.getAttribute("userId");
+		boolean isUpdated = service.markAllAsRead(userId);
+		int unreadCount = service.getUnreadCount(userId);
+		
+		NotificationResponseDto responseDto = new NotificationResponseDto();
+		responseDto.setAllReadStatusesUpdated(isUpdated);
+		responseDto.setUnreadCount(unreadCount);
+		
+		return responseDto;
+	}
+	
 }

--- a/src/main/java/com/my/ex/dao/INotificationDao.java
+++ b/src/main/java/com/my/ex/dao/INotificationDao.java
@@ -11,4 +11,5 @@ public interface INotificationDao {
 	List<NotificationDto> getAllNotifications(Map<String, Object> map);
 	int updateReadStatus(int notificationId);
 	int getUnreadCount(String userId);
+	int markAllAsRead(String userId);
 }

--- a/src/main/java/com/my/ex/dao/NotificationDao.java
+++ b/src/main/java/com/my/ex/dao/NotificationDao.java
@@ -42,4 +42,9 @@ public class NotificationDao implements INotificationDao {
 		return session.selectList(NAMESPACE + "getAllNotifications", map);
 	}
 
+	@Override
+	public int markAllAsRead(String userId) {
+		return session.update(NAMESPACE + "markAllAsRead", userId);
+	}
+
 }

--- a/src/main/java/com/my/ex/dto/NotificationResponseDto.java
+++ b/src/main/java/com/my/ex/dto/NotificationResponseDto.java
@@ -9,4 +9,5 @@ public class NotificationResponseDto {
 	private List<NotificationDto> notificationDtos;
 	private int unreadCount;
 	private boolean readStatusUpdated;
+	private boolean allReadStatusesUpdated ;
 }

--- a/src/main/java/com/my/ex/service/INotificationService.java
+++ b/src/main/java/com/my/ex/service/INotificationService.java
@@ -10,4 +10,5 @@ public interface INotificationService {
 	List<NotificationDto> getAllNotifications(String userId, int size, int offset);
 	boolean updateReadStatus(int notificationId);
 	int getUnreadCount(String userId);
+	boolean markAllAsRead(String userId);
 }

--- a/src/main/java/com/my/ex/service/NotificationService.java
+++ b/src/main/java/com/my/ex/service/NotificationService.java
@@ -46,5 +46,10 @@ public class NotificationService implements INotificationService {
 		
 		return dao.getAllNotifications(map);
 	}
+
+	@Override
+	public boolean markAllAsRead(String userId) {
+		return dao.markAllAsRead(userId) > 0;
+	}
 	
 }

--- a/src/main/resources/mappers/Notificationmapper.xml
+++ b/src/main/resources/mappers/Notificationmapper.xml
@@ -61,4 +61,11 @@
 		 WHERE userId = #{userId} 
 		   AND is_read = 'N'
 	</select>
+	
+	<update id="markAllAsRead">
+		UPDATE mvc_notifications6
+		   SET is_read = 'Y'
+		 WHERE userId = #{userId}
+		   AND is_read = 'N'
+	</update>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/include/loginInfo.jsp
+++ b/src/main/webapp/WEB-INF/views/include/loginInfo.jsp
@@ -49,7 +49,10 @@
 								<div id="notificationModal" class="notification-modal">
 							        <div class="notification-header">
 							            <h3>알림</h3>
-							            <span class="close-modal-btn">&times;</span>
+							            <div class="header-actions">
+								            <button id="markAllAsReadBtn" class="mark-all-read-btn">모두 읽기</button>
+								            <span class="close-modal-btn">&times;</span>
+						            	</div>
 							        </div>
 							        <ul class="notification-list"></ul>
 							        <div class="notification-footer">

--- a/src/main/webapp/WEB-INF/views/user/getNotifications.jsp
+++ b/src/main/webapp/WEB-INF/views/user/getNotifications.jsp
@@ -13,9 +13,14 @@
 	
 	<main class="my-posts-main">
 		<div class="my-posts-container">
+			<div class="page-header">
+	            <h2 class="page-title">알림</h2>
+	            <button id="markAllAsReadBtnPage" class="mark-all-read-btn-page">모두 읽기</button>
+	        </div>
 			<ul class="noti-list"></ul>
 			<div class="spinner-grow spinner-grow-sm"></div>
-		</div>			
+		</div>
+		<div class="no-notifications-message" id="noNotificationsMessage"></div>			
 	</main>
 	
 	<%@ include file="/WEB-INF/views/include/footer.jsp" %>

--- a/src/main/webapp/resources/css/common.css
+++ b/src/main/webapp/resources/css/common.css
@@ -846,6 +846,30 @@ hr {
     color: #0056b3;
 }
 
+/* '모두 읽음' 버튼 스타일 */
+.mark-all-read-btn {
+    background-color: transparent;
+    border: none;
+    color: #999; /* 연한 회색 */
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0;
+    margin-right: 15px; /* 닫기 버튼과의 간격 */
+    transition: color 0.2s ease;
+}
+
+/* hover 시 효과 */
+.mark-all-read-btn:hover {
+    color: #666; /* 조금 더 진한 회색 */
+    text-decoration: none; /* 밑줄 제거 */
+}
+
+.header-actions {
+	display: flex;
+	align-items: center;
+}
+
 /* .buttonn-primary
 ================================================== */
 

--- a/src/main/webapp/resources/css/getNotifications.css
+++ b/src/main/webapp/resources/css/getNotifications.css
@@ -28,6 +28,42 @@ body {
     box-sizing: border-box;
 }
 
+/* 페이지 헤더 스타일 */
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 15px;
+    margin-bottom: 20px;
+}
+
+.page-title {
+    margin: 0;
+    font-size: 1.5em;
+    color: #2c3e50;
+    font-weight: 600;
+}
+
+/* '모두 읽기' 버튼 */
+.mark-all-read-btn-page {
+    background-color: transparent;
+    border: 1px solid #ccc;
+    color: #666;
+    font-size: 0.9em;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 8px 15px;
+    border-radius: 5px;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.mark-all-read-btn-page:hover {
+    background-color: #f0f0f0;
+    border-color: #aaa;
+    color: #333;
+}
+
 /* 알림 목록 <ul> */
 .noti-list {
     list-style: none;
@@ -122,8 +158,10 @@ body {
 
 .spinner-grow {
 	display: none;
-	position: absolute;
-	top: calc(100% + 30px); /* ul 바로 아래 10px 간격 */
+	position: sticky;
+	bottom: 10px; /* 화면 하단에서 띄울 거리 */
+	transform: translateX(-50%);
+	z-index: 9999;
 	left: 50%;
 }
 
@@ -135,6 +173,28 @@ body {
     text-align: center;
     color: #666;
     padding: 10px 0;
+}
+
+.no-notifications-message {
+	position: fixed;
+/* 	top: 10px; */
+	bottom: 20px;
+	left: 50%;
+	transform: translateX(-50%) translateY(0);
+	background-color: black;
+	color: white;
+	padding: 10px 20px;
+	border-radius: 5px;
+	opacity: 0;
+	visibility: hidden;
+	font-size: 14px;
+	z-index: 9999;
+	transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+.no-notifications-message.show {
+	opacity: 1;
+	visibility: visible;
 }
 
 /* 반응형 디자인 */

--- a/src/main/webapp/resources/js/getNotifications.js
+++ b/src/main/webapp/resources/js/getNotifications.js
@@ -102,6 +102,38 @@ document.addEventListener('DOMContentLoaded', () => {
 			badge.textContent = ''
 		}
 	}
+    
+    // '모두 읽음' 버튼 클릭 이벤트 핸들러
+    const markAllRead = () => {
+        markAllAsReadBtnPage.addEventListener('click', () => {
+            const unreadElements = document.querySelectorAll(".unread")
+            if(unreadElements.length > 0){
+                axios.patch('/notification/markAllAsRead')
+				.then(response => {
+					const isUpdated = response.data.allReadStatusesUpdated
+					const unreadCount = response.data.unreadCount
+					if(isUpdated){
+						unreadElements.forEach((unreadElement) => {
+							unreadElement.classList.remove('unread')
+							showUnreadCount(unreadCount)
+						})
+					}
+				})
+				.catch(error => {
+					console.error('error: ', error)
+				})
+            } else {
+                const noNotificationsMessage = document.querySelector("#noNotificationsMessage")
+                const msg = '더 이상 읽을 알림이 없습니다.'
+                noNotificationsMessage.textContent = msg
+                noNotificationsMessage.classList.add('show')
+                
+                setTimeout(() => {
+                    noNotificationsMessage.classList.remove('show')
+                }, 3000)
+            }
+        })
+    }
 
     // 클릭 시 읽음 처리
     const handleNotificationClick = () => {
@@ -150,11 +182,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 다음 알림 데이터 불러오기
     const loadMoreNotifications = (page, observer) => {
-        const params = {
-            page: page,
-            size: 10
-        }
-        
         // 옵저버 종료 후 데이터 없음 알림 메시지
         const handleNoMoreNotifications = () => {
             if(!document.querySelector(".no-more-notifications")){
@@ -167,12 +194,25 @@ document.addEventListener('DOMContentLoaded', () => {
             observer.disconnect()  
         }
 
+        const params = {
+            page: page,
+            size: 10
+        }
+
+        showSpinner() // 요청 직접에 스피너 보이기
         axios.get('/notification/getAllNotifications/axios', { params })
             .then(response => {
                 const notificationList = response.data
                 if(notificationList.length > 0){
                     let output = renderNotificationList(notificationList)
                     container.insertAdjacentHTML('beforeend', output)
+
+                    // 새 sentinel 생성 및 옵저버 연결
+                    const newSentinel = document.createElement('div')
+                    newSentinel.id = 'scroll-sentinel'
+                    container.insertAdjacentElement('beforeend', newSentinel)
+                    newSentinel.insertAdjacentElement('beforebegin', spinner)
+                    observer.observe(newSentinel)
 
                     // 받은 데이터가 요청한 size보다 작으면 더 이상 데이터 없으므로 옵저버 종료
                     if(notificationList.length < params.size){
@@ -236,4 +276,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
     initInfiniteScrollObserver()
     handleNotificationClick()
+    markAllRead()
 })

--- a/src/main/webapp/resources/js/loginInfo.js
+++ b/src/main/webapp/resources/js/loginInfo.js
@@ -160,11 +160,47 @@ document.addEventListener('DOMContentLoaded', () => {
 	const badge = document.querySelector("#notificationBadge")
 	const showUnreadCount = (unreadCount) => {
 		if(unreadCount > 0){
+			// 뱃지에 안 읽은 메시지 수 표시
 			badge.style.display = 'block'
 			badge.textContent = unreadCount
+
+			// '모두 읽음' 버튼 표시
+        	markAllAsReadBtn.style.display = 'block';
 		} else {
 			badge.style.display = 'none'
 			badge.textContent = ''
+		}
+	}
+
+	const markAllAsReadBtn = document.querySelector("#markAllAsReadBtn")
+	// '모두 읽음' 버튼 클릭 이벤트 핸들러
+	const markAllAsRead = () => {
+		markAllAsReadBtn.addEventListener('click', () => {
+			axios.patch('/notification/markAllAsRead')
+				.then(response => {
+					const isUpdated = response.data.allReadStatusesUpdated
+					const unreadCount = response.data.unreadCount
+					if(isUpdated){
+						document.querySelectorAll(".unread").forEach((unreadElement) => {
+							unreadElement.classList.remove('unread')
+							showUnreadCount(unreadCount)
+						})
+					}
+				})
+				.catch(error => {
+					console.error('error: ', error)
+				})
+		})
+	}
+
+	// 안 읽은 메시지가 있다면 '모두 읽기' 버튼 표시
+	
+	const showMarkAllAsReadButton = (unreadCount) => {
+		if(unreadCount > 0){
+			markAllAsReadBtn.style.display = 'block'
+			markAllAsRead()
+		} else {
+			markAllAsReadBtn.style.display = 'none'
 		}
 	}
 
@@ -188,6 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				axios.get('/notification/getNotifications')
 					.then(response => {
 						const notifications = response.data.notificationDtos // List<>
+						const unreadCount = response.data.unreadCount
 
 						// 초기화
 						const notificationListContainer  = notificationModal.querySelector(".notification-list") // <ul>
@@ -200,6 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
 						}
 
 						// 알림이 있는 경우
+						showMarkAllAsReadButton(unreadCount)
 						let output = renderNotificationList(notifications)
 						const infoMessage = 
 						`


### PR DESCRIPTION
## 📌 변경 사항
- 드롭다운 알림 목록에 "모두 읽기" 버튼 추가
- 전체 알림 페이지에서도 "모두 읽기" 버튼 항상 표시되도록 처리
- 응답에 따라 UI에서도 `.unread` 클래스 제거 및 알림 뱃지 수 동기화
- 읽지 않은 알림이 없는 상태에서 클릭 시 토스트 메시지 노출
- 무한 스크롤 sentinel 동적 생성 로직 추가
  - 매 페이지 로딩 시마다 새로운 sentinel `<div id="scroll-sentinel">` 생성
  - 새 sentinel에 `IntersectionObserver`를 다시 연결

## 🛠️ 수정한 이유
- 알림을 일괄 읽음 처리하여 사용자 조작 편의성 향상
- 읽지 않은 알림이 없을 경우 버튼 클릭 시 불필요한 요청 방지
- spinner가 항상 하단에 고정되지 않고 새 sentinel 위치 근처에서 자연스럽게 노출되도록 개선

## 🔍 주요 변경 파일
- NotificationController.java
- NotificationDao.java
- NoficiationResponseDto.java
- NotificationService.java
- Notificationmapper.xml
- loginInfo.jsp
- getNotification.jsp
- common.css
- getNotifications.css
- getNotifications.js
- loginInfo.js

## ✅ 테스트 내용
- [x] "모두 읽기" 버튼 동작 확인
- [x] 읽음 처리 후 UI 상태 동기화 확인
- [x] 무한 스크롤 시 새로운 알림 정상 로드
- [x] 스크롤 하단에서 spinner 노출 위치 확인
- [x] 옵저버가 연속적으로 작동하여 다음 알림도 잘 불러오는지 확인
- [x] 알림이 모두 로딩되었을 때 observer 종료 및 메시지 표시 확인

## 🔗 관련 이슈
closes #88 