### PR TITLE
[BUG] 알림 아이콘 클릭 시 3일이 지난 읽지 않은 알림이 표시되지 않음

### DIFF
--- a/src/main/webapp/resources/js/loginInfo.js
+++ b/src/main/webapp/resources/js/loginInfo.js
@@ -94,7 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		notifications.forEach((notificationDto) => {
 			// 상대적인 시간으로 변환
 			const timeStamp = notificationDto.createdAt
-			const date = timeAgo(timeStamp)
+			const date = timeAgo(new Date(timeStamp))
 
 			// 읽음 여부 표시 클래스
 			let readClass = notificationDto.isRead == 'N'? 'unread' : ''


### PR DESCRIPTION
## 📌 변경 사항
- 프론트엔드에서 `getFullYear()` 오류가 발생하지 않도록 `timestamp`를 `Date` 객체로 변환해 전달하도록 변경

## 🛠️ 수정한 이유
- 읽지 않은 알림이 3일이 지나면 리스트에 표시되지 않는 문제가 발생
- 원인을 찾던 중 날짜 포맷 처리 시 `timestamp.getFullYear is not a function` 오류로 알림 렌더링이 실패했음을 발견함

## 🔍 주요 변경 파일
- loginInfo.js

## ✅ 테스트 내용
- 3일 이상 지난 읽지 않은 알림도 리스트에 정상적으로 표시되는지 확인
- 기존 3일 이내의 알림 및 읽은 알림 정상 출력 확인

## 🔗 관련 이슈
closes #91 