### PR TITLE
[ENH] 알림 아이콘 클릭 시 '모든 알림 보기' 항상 표시 및 알림이 있을 때만 '모두 읽기' 버튼 동작하도록 개선

### DIFF
--- a/src/main/webapp/resources/css/common.css
+++ b/src/main/webapp/resources/css/common.css
@@ -827,7 +827,7 @@ hr {
 
 /* 모달 푸터 */
 .notification-footer {
-	display: none;
+	display: block;
     padding: 15px 20px;
     text-align: center;
     border-top: 1px solid #eee;

--- a/src/main/webapp/resources/css/getNotifications.css
+++ b/src/main/webapp/resources/css/getNotifications.css
@@ -46,6 +46,10 @@ body {
 }
 
 /* '모두 읽기' 버튼 */
+.mark-all-read-btn-page.hidden {
+	display: none;
+}
+
 .mark-all-read-btn-page {
     background-color: transparent;
     border: 1px solid #ccc;

--- a/src/main/webapp/resources/js/getNotifications.js
+++ b/src/main/webapp/resources/js/getNotifications.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const notificationListJson = document.querySelector("#notificationAllList").getAttribute("data-notificationAllList")
     const container = document.querySelector(".noti-list") // <ul>
     const spinner = document.querySelector(".spinner-grow")
+    const markAllAsReadBtnPage = document.querySelector("#markAllAsReadBtnPage")
 
     // 상대적인 시간으로 변환
     const timeAgo = (timestamp) => {
@@ -265,16 +266,21 @@ document.addEventListener('DOMContentLoaded', () => {
         `
             <div id="scroll-sentinel"></div>
         `
+        container.innerHTML = output
+
+        initInfiniteScrollObserver() // 무한 스크롤
+        handleNotificationClick() // 각 알림 클릭 시 읽음 처리
+        markAllAsReadBtnPage.classList.remove('hidden') // '모두 읽기' 버튼 표시
+        markAllRead() // 모두 읽기    
     } else {
         output = 
         `
             <li class="no-noti">알림 내역이 없습니다.</li>
         `
+        container.innerHTML = output
+        
+        markAllAsReadBtnPage.classList.add('hidden') // '모두 읽기' 버튼 숨기기
     }
     
-    container.innerHTML = output
-
-    initInfiniteScrollObserver()
-    handleNotificationClick()
-    markAllRead()
+    
 })

--- a/src/main/webapp/resources/js/loginInfo.js
+++ b/src/main/webapp/resources/js/loginInfo.js
@@ -245,9 +245,7 @@ document.addEventListener('DOMContentLoaded', () => {
 							<li class="notification-info-message">최근 3일 이내의 알림만 표시됩니다.</li>
 						`
 						output += infoMessage
-
 						notificationListContainer.innerHTML = output
-						notificationModal.querySelector(".notification-footer").style.display = 'block' // '모든 알림 보기' 표시
 						
 						// notificationListContainer.appendChild(infoMessage)
 						


### PR DESCRIPTION
## 📌 변경 사항
- 알림 아이콘 클릭 시 '모든 알림 보기' 링크를 항상 표시함으로써 사용자가 언제든지 전체 알림을 확인할 수 있도록 UX 개선
- 알림 내역이 1개 이상 있을 경우에만 다음 동작을 실행하도록 조건 분기 처리
  - 알림 리스트 렌더링
  - 무한 스크롤 옵저버 등록 (`initInfiniteScrollObserver()`)
  - 각 알림 클릭 시 읽음 처리 이벤트 등록 (`handleNotificationClick()`)
  - '모두 읽기' 버튼 표시 및 기능 활성화 (`markAllRead()`)
- 알림 내역이 없는 경우
  - '알림 내역이 없습니다' 메시지를 렌더링
  - '모두 읽기' 버튼 숨김 처리 (`.hidden` 클래스 적용)

## 🛠️ 수정한 이유
- 알림 아이콘 클릭 시 
  - 기존에는 최근 3일 이내 알림이 없고, 읽지 않은 알림도 없으면 '모든 알림 보기' 링크가 보이지 않아 사용자가 전체 알림 내역을 확인할 방법이 제한됨
- 모든 알림 보기 클릭 시
  - 알림이 없을 때는 옵저버 등의 기능이 실행되지 않도록 조건 분기를 적용해 불필요한 로직 실행 방지
  - '모두 읽기' 버튼이 항상 보이던 기존 방식에서 → 알림 내역이 있을 때만 보이도록 UX 개선

## 🔍 주요 변경 파일
- common.css
- getNotifications.css
- getNotifications.js
- loginInfo.js

## ✅ 테스트 내용
- 알림 아이콘 클릭 시
  - [x] '모든 알림 보기' 링크가 화면에 정상적으로 표시되는지 확인
- 모든 알림 보기 클릭 시
  - [x] 알림이 존재할 때: 알림 렌더링, 무한 스크롤, 읽음 처리, 버튼 표시 정상 작동
  - [x] 알림이 없을 때: '알림 없음' 메시지 표시, 버튼 숨김, 불필요한 로직 미실행
  - [x] 기존 알림 기능에 영향 없는지 확인
  - [x] JS 콘솔 에러 없음 확인

## 🔗 관련 이슈
closes #94 
